### PR TITLE
Do not explicitly deny access to a post

### DIFF
--- a/inc/class-post-type.php
+++ b/inc/class-post-type.php
@@ -204,13 +204,12 @@ class Post_Type {
 			true
 		);
 
-		if ( intval( $assigned_user ) !== intval( $user_id ) ) {
-			// Explicitly deny access to this post since it is not a current assignment.
-			return [ 'do_not_allow' ];
+		// Allow ability to edit this post.
+		if ( intval( $assigned_user ) === intval( $user_id ) ) {
+			return [ 'edit_posts' ];
 		}
 
-		// Allow ability to edit this post.
-		return [ 'edit_posts' ];
+		return $caps;
 	}
 
 	/**


### PR DESCRIPTION
This fixes a bug with competing map_meta_cap filters. We shouldn't explicitly deny access to a post, only grant access if our criteria is met (that the user has an active assigned task).